### PR TITLE
fix: ignore unordered lists in code blocks from parsing as a fragmented list

### DIFF
--- a/src/processors/fragmentProcessor.ts
+++ b/src/processors/fragmentProcessor.ts
@@ -6,37 +6,42 @@ export class FragmentProcessor {
 	private parser: CommentParser;
 	private fragmentCounter = 1;
 	private orderedListRegex = /\d\) /g;
+	private codeBlockRegex = /```[^\n]*(?:\n[^`]*\n)```/g;
 
 	constructor() {
 		this.parser = new CommentParser();
 	}
 
 	process(markdown: string, options: Options) {
-		let output = markdown;
+		const separatorRegexp = new RegExp(`${options.separator}|${options.verticalSeparator}`, 'gmi');
 
-		markdown
-			.split(new RegExp(options.separator, 'gmi'))
-			.map((slidegroup) => {
-				return slidegroup
-					.split(new RegExp(options.verticalSeparator, 'gmi'))
-					.map((slide) => {
-						this.fragmentCounter = 1;
+		// Detect line ranges containing Markdown code blocks so we can ignore them
+		const codeBlockLines = Array.from(markdown.matchAll(this.codeBlockRegex))
+			.map(({ 0: match, index }) => ({
+				from: markdown.substring(0, index).split('\n').length - 1,
+				to: markdown.substring(0, index + match.length).split('\n').length - 1
+			}));
 
-						const newSlide = slide.split('\n')
-							.map((line) => {
-								if (line.trim().startsWith("+ ") || this.orderedListRegex.test(line.trim())) {
-									return this.transformLine(line);
-								}
-								return line;
-							})
-							.join('\n');
-						output = output.split(slide).join(newSlide);
-						return newSlide;
+		const output = markdown
+			.split('\n')
+			.map((line, lineNumber) => {
+				if (`\n${line}\n`.match(separatorRegexp)) {
+					// Reset counter when encountered slide separator
+					this.fragmentCounter = 1;
+					return line;
+				}
 
-					})
-					.join(options.verticalSeparator);
+				const isCodeblockLine = codeBlockLines.some(({ from, to }) => lineNumber >= from && lineNumber <= to);
+				if (isCodeblockLine) {
+					return line;
+				}
+
+				if (line.trim().startsWith("+ ") || this.orderedListRegex.test(line.trim())) {
+					return this.transformLine(line);
+				}
+				return line;
 			})
-			.join(options.separator);
+			.join('\n');
 
 		return output;
 	}

--- a/test/__snapshots__/extendedSyntax.unit.test.ts.snap
+++ b/test/__snapshots__/extendedSyntax.unit.test.ts.snap
@@ -69,6 +69,18 @@ exports[`Extended Markdown Syntax >  Fragmented list 1`] = `
 
 ---
 
+# Fragmented unordered list with ignored code block
+
+- First
+- Second<!-- .element: class=\\"fragment\\" data-fragment-index=\\"1\\" -->
+
+\`\`\`diff
+- ignored block text 1
++ ignored block text 2
+\`\`\`
+
+---
+
 # Ordered list
 
 1. First

--- a/test/comment.unit.test.ts
+++ b/test/comment.unit.test.ts
@@ -2,7 +2,7 @@ import { CommentParser, Comment } from "src/comment";
 import { YamlStore } from "src/yamlStore";
 import { getSlideOptions } from "./testUtils";
 
-test('Parse Coment', () => {
+test('Parse Comment', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 	const parser = new CommentParser();
 
@@ -17,7 +17,7 @@ test('Parse Coment', () => {
 	expect(parsed).toStrictEqual(expected);
 });
 
-test('Parse Coment', () => {
+test('Parse Comment', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 
 	const parser = new CommentParser();
@@ -48,7 +48,7 @@ test('Empty Slide comment', () => {
 	expect(parsed).toStrictEqual(expected);
 });
 
-test('Parse Coment', () => {
+test('Parse Comment', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 
 	const parser = new CommentParser();
@@ -65,7 +65,7 @@ test('Parse Coment', () => {
 	expect(parsed).toStrictEqual(expected);
 });
 
-test('Parse Coment', () => {
+test('Parse Comment', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 
 	const parser = new CommentParser();
@@ -80,7 +80,7 @@ test('Parse Coment', () => {
 	expect(parsed).toStrictEqual(expected);
 });
 
-test('Parse Coment with bg property', () => {
+test('Parse Comment with bg property', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 
 	const parser = new CommentParser();
@@ -97,7 +97,7 @@ test('Parse Coment with bg property', () => {
 	expect(parsed).toStrictEqual(expected);
 });
 
-test('Parse Coment with bg property', () => {
+test('Parse Comment with bg property', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 
 	const parser = new CommentParser();
@@ -110,12 +110,12 @@ test('Parse Coment with bg property', () => {
 		[],
 		['has-dark-background'],
 		new Map<string, string>([["data-background-color","black"]])
-	
+
 	);
 	expect(parsed).toStrictEqual(expected);
 });
 
-test('Merge Coment', () => {
+test('Merge Comment', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 
 	const parser = new CommentParser();
@@ -143,7 +143,7 @@ test('Invalid input', () => {
 	expect(parsed).toBeNull();
 });
 
-test('Parse Coment with pad property', () => {
+test('Parse Comment with pad property', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 
 	const parser = new CommentParser();
@@ -158,7 +158,7 @@ test('Parse Coment with pad property', () => {
 	expect(parsed).toStrictEqual(expected);
 });
 
-test('Parse Coment with animate property', () => {
+test('Parse Comment with animate property', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 
 	const parser = new CommentParser();
@@ -174,7 +174,7 @@ test('Parse Coment with animate property', () => {
 	expect(parsed).toStrictEqual(expected);
 });
 
-test('Parse Coment with fragment property', () => {
+test('Parse Comment with fragment property', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 
 	const parser = new CommentParser();
@@ -191,7 +191,7 @@ test('Parse Coment with fragment property', () => {
 	expect(parsed).toStrictEqual(expected);
 });
 
-test('Parse Coment with opacity property', () => {
+test('Parse Comment with opacity property', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 
 	const parser = new CommentParser();
@@ -206,7 +206,7 @@ test('Parse Coment with opacity property', () => {
 	expect(parsed).toStrictEqual(expected);
 });
 
-test('Parse Coment with border property', () => {
+test('Parse Comment with border property', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 
 	const parser = new CommentParser();
@@ -221,7 +221,7 @@ test('Parse Coment with border property', () => {
 	expect(parsed).toStrictEqual(expected);
 });
 
-test('Parse Coment with rotate property', () => {
+test('Parse Comment with rotate property', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 
 	const parser = new CommentParser();
@@ -237,7 +237,7 @@ test('Parse Coment with rotate property', () => {
 
 });
 
-test('Parse Coment with rotate property', () => {
+test('Parse Comment with rotate property', () => {
 	YamlStore.getInstance().options = getSlideOptions({})
 
 	const parser = new CommentParser();

--- a/test/extendedSyntax.unit.test.ts
+++ b/test/extendedSyntax.unit.test.ts
@@ -211,7 +211,7 @@ note: this is not! Only the speaker might see this text.
 - and this bulletpoint
 - or this picture
 
-![](https://picsum.photos/id/1005/250/250) 
+![](https://picsum.photos/id/1005/250/250)
 `;
 
 	const { options, markdown } = prepare(input);
@@ -237,6 +237,18 @@ test('Extended Markdown Syntax >  Fragmented list', () => {
 + First
 + Second
 + Third
+
+---
+
+# Fragmented unordered list with ignored code block
+
+- First
++ Second
+
+\`\`\`diff
+- ignored block text 1
++ ignored block text 2
+\`\`\`
 
 ---
 


### PR DESCRIPTION
I've added logic that first finds line ranges containing code blocks and then ignores lines from parsing by `FragmentProcessor` if they are within found code block ranges. I've also updated test and snapshot to test this case.
 
fixes #45 