### PR TITLE
Remove "fix" for empty lines in multiline LaTeX expressions

### DIFF
--- a/src/processors/latexProcessor.ts
+++ b/src/processors/latexProcessor.ts
@@ -56,10 +56,6 @@ export class LatexProcessor {
 						return '`' + line + '`';
 					}
 				})
-				.map(line => {
-					//Replace all empty lines in multiline LaTex expressions
-					return line.replaceAll(/^\s*[\r\n]/gm, '');
-				})
 				.join('$$')
 				.slice(1, -1);
 		}


### PR DESCRIPTION
Empty lines in LaTeX multiline expressions are not allowed by default (will not compile). This attempt to "fix" empty lines causes issues. E.g. try

```
text $a$

text

$$
aa
$$

text $a$

$$
aa
$$
```