### PR TITLE
Fix footnote processor so that footnotes can be formatted by markdown processor

### DIFF
--- a/src/processors/footNoteProcessor.ts
+++ b/src/processors/footNoteProcessor.ts
@@ -64,7 +64,7 @@ export class FootnoteProcessor {
 		footNotesBlock += '<ol>\n';
 
 		footNotes.forEach((value, key) => {
-			footNotesBlock += '<li id="fn:' + key + '" role="doc-endnote"><p>' + value + '&nbsp;</p></li>';
+			footNotesBlock += '<li id="fn:' + key + '" role="doc-endnote"><p>\n\n' + value + '\n\n</p></li>';
 		});
 
 		footNotesBlock += '</ol>\n';


### PR DESCRIPTION
Need these newlines for the final-stage markdown processor to format `value` into HTML.

Try `[^1]: Text $H\Psi = E\Psi$ https://www.uiuc.edu`. Without `\n\n`, equation has ` around them, and URL is not wrapped in `<a>`.

Not sure what `&nbsp;` is for, so I deleted it.