### PR TITLE
Removed escaping "$" symbol for code block in latexProcessor

### DIFF
--- a/src/processors/latexProcessor.ts
+++ b/src/processors/latexProcessor.ts
@@ -34,6 +34,15 @@ export class LatexProcessor {
 	}
 
 	private processSingleLine(markdown: string) {
+
+		let insideCodeBlock = false;
+		if (markdown.indexOf('```') > -1) {
+			insideCodeBlock = !insideCodeBlock;
+		}
+		if (insideCodeBlock) {
+			return markdown;
+		}
+
 		return markdown
 			.split('\n')
 			.map(line => {


### PR DESCRIPTION
Closes: #159 

I am very unfamiliar with TypeScript/JavaScript. I hope I found the problem correctly. Anyway, in the presentation that I need soon, this solution helped me 😂