### PR TITLE
Add support for setting the height, and using the installed theme colors of charts

### DIFF
--- a/src/processors/chartProcessor.ts
+++ b/src/processors/chartProcessor.ts
@@ -46,7 +46,7 @@ export class ChartProcessor {
 			if (endIdx < 0) {
 				return markdown;
 			}
-			let colorMap=[...this.colorMap];
+			const colorMap=[...this.colorMap];
 
 			const before = markdown.substring(0, startIdx);
 			const after = markdown.substring(endIdx + 3);
@@ -64,11 +64,11 @@ export class ChartProcessor {
 				};
 				
 				if (this.useThemeColorsRegex.test(chartMarkup)){
-					const [, key, value] = this.useThemeColorsRegex.exec(chartMarkup);
+					const [, , value] = this.useThemeColorsRegex.exec(chartMarkup);
 
 					if (value.trim() == "true"){
 						for (let i=0;i<7;i++){
-							let style=getComputedStyle(document.body).getPropertyValue("--chart-color-"+(i+1));
+							const style=getComputedStyle(document.body).getPropertyValue("--chart-color-"+(i+1));
 							if (style != "") {
 								colorMap[i]=style;
 							}
@@ -166,7 +166,7 @@ export class ChartProcessor {
 
 					}
 					if (this.heightRegex.test(chartMarkup)){
-						const [, key, value] = this.heightRegex.exec(chartMarkup);
+						const [, , value] = this.heightRegex.exec(chartMarkup);
 						options.height = +value;
 
 					}


### PR DESCRIPTION
Hi,
I wanted to have the ability to use the theme colors (as it is supported by the charts plugin) for charts and their height. So I added this little piece of code that allows to add to new fields:
* `useThemeColors: true` will check the `--chart-color-X` css styles to get the value for the corresponding bar
* `height: 400px` will set the max-height attribute of the canvas to that number, allowing to have something different than full height.

Maybe that is something you want to integrate into the code, or maybe you know a better way of doing this. 

Thanks for creating this plugin! It's really cool.