### PR TITLE
Add additional control over Reveal.js Server

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ interface EmbeddedSlideParameters {
 export interface AdvancedSlidesSettings {
 	port: string;
 	autoReload: boolean;
+	autoStart: boolean;
 	exportDirectory: string;
 	enableOverview: boolean;
 	enableChalkboard: boolean;
@@ -61,6 +62,7 @@ export interface AdvancedSlidesSettings {
 const DEFAULT_SETTINGS: AdvancedSlidesSettings = {
 	port: '3000',
 	autoReload: true,
+	autoStart: true,
 	exportDirectory: '/export',
 	enableChalkboard: false,
 	enableOverview: false,
@@ -144,7 +146,10 @@ export default class AdvancedSlidesPlugin extends Plugin {
 		}
 
 		this.revealServer = new RevealServer(this.obsidianUtils, this.settings.port);
-		this.revealServer.start();
+		if (this.settings.autoStart) {
+			this.revealServer.start();
+		}
+		
 
 		try {
 			this.registerView(REVEAL_PREVIEW_VIEW, leaf => new RevealPreviewView(leaf, this.revealServer.getUrl(), this.settings, this.hideView.bind(this)));
@@ -506,6 +511,20 @@ class AdvancedSlidesSettingTab extends PluginSettingTab {
 						}, 750),
 					);
 			});
+
+		new Setting(containerEl)
+			.setName('Auto Start Server')
+			.setDesc('Should Advanced Slides Preview server be started at Obsidian startup? (default: true)')
+			.addToggle(value => 
+				value
+					.setValue(this.plugin.settings.autoStart)
+					.onChange(
+						_.debounce(async value => {
+							this.plugin.settings.autoStart = value;
+							await this.plugin.saveSettings();
+						}, 750),
+					),
+			)
 
 		new Setting(containerEl)
 			.setName('Port')

--- a/src/main.ts
+++ b/src/main.ts
@@ -194,6 +194,23 @@ export default class AdvancedSlidesPlugin extends Plugin {
 				},
 			});
 
+
+			this.addCommand({
+				id: 'stop-server-advanced-slides-preview',
+				name: 'Stop Slide Preview Server',
+				callback: () => {
+					this.revealServer.stop()
+				}
+			});
+
+			this.addCommand({
+				id: 'start-server-advanced-slides-preview',
+				name: 'Start Slide Preview Server',
+				callback: () => {
+					this.revealServer.start()
+				}
+			})
+
 			this.addSettingTab(new AdvancedSlidesSettingTab(this.app, this));
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -199,7 +199,7 @@ export default class AdvancedSlidesPlugin extends Plugin {
 				id: 'stop-server-advanced-slides-preview',
 				name: 'Stop Slide Preview Server',
 				callback: () => {
-					this.revealServer.stop()
+					this.revealServer.stop();
 				}
 			});
 
@@ -207,7 +207,7 @@ export default class AdvancedSlidesPlugin extends Plugin {
 				id: 'start-server-advanced-slides-preview',
 				name: 'Start Slide Preview Server',
 				callback: () => {
-					this.revealServer.start()
+					this.revealServer.start();
 				}
 			})
 


### PR DESCRIPTION
it bothers me a little that reveal.js server is started by default. I want to have control over starting and stopping the server, so I added 2 commands "start server" and "stop server", as well as an option for automatic start (it's enabled by default for backward compatibility). I've built it and checked that it works in my vault