### PR TITLE
typo: chalkboard option redundant space

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -679,7 +679,7 @@ class AdvancedSlidesSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('Chalkboard')
-			.setDesc('Should the slides contain a chalkboard ?')
+			.setDesc('Should the slides contain a chalkboard?')
 			.addToggle(value =>
 				value.setValue(this.plugin.settings.enableChalkboard).onChange(
 					_.debounce(async value => {


### PR DESCRIPTION
removes redundant space in the chalkboard config

![image](https://github.com/MSzturc/obsidian-advanced-slides/assets/3660408/60073d00-fb78-41a0-88d8-11ca03944d21)
