### PR TITLE
add remoteCSS option to front matter and template

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -8,6 +8,7 @@ export type Options = {
 	enableLinks: boolean;
 	title: string;
 	css: string | string[];
+	remoteCSS: string | string[];
 	width: number;
 	height: number;
 	margin: number;

--- a/src/revealRenderer.ts
+++ b/src/revealRenderer.ts
@@ -1,16 +1,16 @@
-import { readFile } from 'fs-extra';
-import { join, basename, extname } from 'path';
-import { glob } from 'glob';
-import Mustache from 'mustache';
-import { md } from './markdown';
+import { basename, extname, join } from 'path';
 
-import defaults from './defaults.json';
+import { ImageCollector } from './imageCollector';
+import Mustache from 'mustache';
 import { ObsidianMarkdownPreprocessor } from './obsidianMarkdownPreprocessor';
 import { ObsidianUtils } from './obsidianUtils';
-import { YamlParser } from './yamlParser';
-import { ImageCollector } from './imageCollector';
 import { RevealExporter } from './revealExporter';
+import { YamlParser } from './yamlParser';
 import _ from 'lodash';
+import defaults from './defaults.json';
+import { glob } from 'glob';
+import { md } from './markdown';
+import { readFile } from 'fs-extra';
 
 export class RevealRenderer {
 	private processor: ObsidianMarkdownPreprocessor;
@@ -78,6 +78,7 @@ export class RevealRenderer {
 		const slides = this.slidify(processedMarkdown, slidifyOptions);
 
 		const cssPaths = this.getCssPaths(options.css);
+		const remoteCSSPaths = this.getCssPaths(options.remoteCSS);
 
 		const settings = this.yaml.getTemplateSettings(options);
 
@@ -95,6 +96,7 @@ export class RevealRenderer {
 			themeUrl,
 			highlightThemeUrl,
 			cssPaths,
+			remoteCSSPaths,
 			base,
 			enableCustomControls,
 			enableChalkboard,

--- a/src/template/embed.html
+++ b/src/template/embed.html
@@ -13,6 +13,9 @@
 	{{#cssPaths}}
     <link rel="stylesheet" href="{{{base}}}{{{.}}}" />
     {{/cssPaths}}
+	{{#remoteCSSPaths}}
+    <link rel="stylesheet" href="{{{.}}}" />
+    {{/remoteCSSPaths}}
 
     <script defer src="{{{base}}}dist/fontawesome/all.min.js"></script>
 

--- a/src/template/reveal.html
+++ b/src/template/reveal.html
@@ -23,6 +23,10 @@
 	{{#cssPaths}}
     <link rel="stylesheet" href="{{{base}}}{{{.}}}" />
     {{/cssPaths}}
+    
+	{{#remoteCSSPaths}}
+    <link rel="stylesheet" href="{{{.}}}" />
+    {{/remoteCSSPaths}}
 
     <script defer src="{{{base}}}dist/fontawesome/all.min.js"></script>
 


### PR DESCRIPTION
I hope this is alright. I made an edit to load remoteCSS files. I saw that this feature should be supported but doesn't work because the current css front matter is appending a "/" to the <link> in the templates. 

Open to feedback/edits and can understand if "remoteCSS" + "css" front matter causes confusion. 