### PR TITLE
Use path to check for relative includes.

### DIFF
--- a/src/obsidianUtils.ts
+++ b/src/obsidianUtils.ts
@@ -48,7 +48,7 @@ export class ObsidianUtils {
 
 		const allFiles = this.app.vault.getFiles();
 		const filesNotInExportDir = allFiles.filter(item => !item.path.contains(expDir));
-		const allHits = filesNotInExportDir.filter(item => item.name == filename);
+		const allHits = filesNotInExportDir.filter(item => item.path.includes(filename));
 
 		let file: TFile = null;
 


### PR DESCRIPTION
As noted in #239, when doing an embedded note that includes a path (relative or absolute), it is not included and instead shows up as literal text.

This changes the method by which files are filtered to instead filter on whether the path includes the filename or not; this may increase somewhat the number of returned results, but it does now allow things like

```
![[lecture-00/welcome-to-class]]
```

to correctly be included in the results.
