### PR TITLE
Upgrades reveal mermaid plugin to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"obsidian": "^0.16.3",
 		"reveal.js": "^4.5.0",
 		"reveal.js-menu": "^2.1.0",
-		"reveal.js-mermaid-plugin": "^1.0.0",
+		"reveal.js-mermaid-plugin": "^2.1.0",
 		"reveal.js-plugins": "^4.1.5",
 		"reveal.js-elapsed-time-bar": "https://github.com/tkrkt/reveal.js-elapsed-time-bar.git",
 		"reveal-pointer": "https://github.com/burnpiro/reveal-pointer.git",


### PR DESCRIPTION
Upgrades to reveal.js-mermaid-plugin 2.1.0 which has mermaid.js 10.6.1.

Had some issues with displaying this diagram:
```mermaid
flowchart LR
	Domain -- has many --> System
	System -- has many --> Component
	Component -- provides --> API
	API -. used by .-> Component
		
```
The arrow heads were not visible. Upgrading the plugin to 2.1.0 fixed the issue. Suppose it was a bug in the 9.x build of mermaid.