### PR TITLE
Add helpful text for configuring excalidraw for working integration

### DIFF
--- a/docs/content/extend-syntax/excalidraw.md
+++ b/docs/content/extend-syntax/excalidraw.md
@@ -4,7 +4,7 @@ description = ""
 weight = 10
 +++
 
-{{%alert%}}It’s required to activate Auto-Export SVG / PNG in Excalidraw Settings.{{%/alert%}}
+{{%alert%}}It’s required to activate Auto-Export SVG / PNG in Excalidraw Settings. You also need to make sure that the excalidraw files have the `.excalidraw.md` extension, not `.md`.{{%/alert%}}
 
 ```md
 #### Excalidraw support


### PR DESCRIPTION
While using your excellent plug (great work, thanks), I noticed that the excalidraw support didn't work.

It turned out that excalidraw by default creates `.md` files (i'm not sure if this is the new default, or I changed it myself), but they need to be `.excalidraw.md` for advanced slides to treat it as an image, not embedded markdown.

I added this to documentation to help others facing the same problem.

I'm unfamiliar with the markup language you use, so I just added the text where I though appropriate.

I'll gladly reword, or rearrange.